### PR TITLE
Remote exporter mirroring, log forwarding, structured logging override option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ kubiks-data/
 # Instrumentation build artifacts
 node_modules/
 dist/
+
+coverage.html

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ export function register() {
   registerOTel({
     serviceName: "your-project-name",
     traceExporter: new OTLPHttpJsonTraceExporter({
-      url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+      // Prefer traces-specific endpoint, fallback to base
+      url: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT || process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
     }),
   });
 }
@@ -78,7 +79,43 @@ const result = await generateText({
 kubiks
 ```
 
-This will automatically configure the OpenTelemetry environment variables and start capturing traces from your Next.js application.
+This will automatically configure OpenTelemetry and start capturing traces from your Next.js application.
+
+## ⚙️ Configuration (env)
+
+- Local-first guarantees
+  - Kubiks runs a local OTLP HTTP collector at `http://localhost:7432` and always writes to a local SQLite DB used by the UI and MCP. This path is permanent.
+  - Remote export is an additional mirror.
+
+- Endpoints
+  - `OTEL_EXPORTER_OTLP_ENDPOINT` (base, e.g. `http://collector:4318`) — used to derive per-signal endpoints if not explicitly set
+  - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (override) — if set, used as remote mirror target for traces; the app still also sends traces to `http://localhost:7432/v1/traces`
+  - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` (override) — remote mirror target for logs
+  - `OTEL_EXPORTER_OTLP_PROTOCOL` — `http/json` (default)
+  - `OTEL_EXPORTER_OTLP_HEADERS` — comma-separated `Key=Value` pairs for auth (e.g., `Authorization=Bearer <token>`)
+
+- Console logs forwarding
+  - Kubiks captures your app `stdout`/`stderr` and forwards them to the remote logs endpoint as OTLP/HTTP JSON (and always stores them locally for the UI):
+    - Derives remote logs endpoint from base → `/v1/logs` unless `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is set
+  - Optional single-line JSON console output (less row spam):
+    - `KUBIKS_LOGS_SINGLE_LINE_JSON=true`
+    - Wraps console methods to emit a single JSON line per call: `{time, level, service, message}`
+
+## 🧭 How it works
+
+- Local collector: `:7432`
+  - Receives OTLP HTTP JSON: `/v1/traces`, `/v1/logs`, `/v1/metrics`
+  - Inserts into local SQLite (UI + MCP read from here)
+  - If remote endpoints are configured, mirrors the same payloads upstream (local write never depends on remote success)
+
+- App launcher
+  - Always sets `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:7432/v1/traces` for the Next.js dev server to ensure the local DB is populated
+  - Uses your `.env` to derive the remote mirror target(s)
+
+## 🧠 MCP integration
+
+- MCP tools fetch from the local SQLite DB (never the remote).
+- Because we always write locally first, MCP remains fully functional even if the remote collector is down.
 
 ## 🤝 Contributing
 

--- a/internal/executor/nextjs.go
+++ b/internal/executor/nextjs.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -34,11 +36,26 @@ func (e *NextJSExecutor) RunDirect() error {
 	}
 
 	serviceName := e.getServiceNameFromPackageJSON()
-	collectorPort := "7432"
 	fmt.Println("🚀 Starting Next.js development server with OpenTelemetry environment configuration...")
 	fmt.Printf("🏷️  Service name: %s\n", serviceName)
-	fmt.Printf("🔗 OTEL Endpoint: http://localhost:%s\n", collectorPort)
-	fmt.Println("📡 OTEL Protocol: http/json")
+
+	// Resolve exporter endpoint and protocol from project .env files
+	resolvedEndpoint, resolvedProtocol := e.resolveExporterConfig()
+	fmt.Printf("🔗 OTEL Endpoint: %s\n", resolvedEndpoint)
+	fmt.Printf("📡 OTEL Protocol: %s\n", resolvedProtocol)
+
+	// Warn if using an external collector (non-localhost)
+	if u, err := url.Parse(resolvedEndpoint); err == nil {
+		host := u.Hostname()
+		if host != "localhost" && host != "127.0.0.1" && host != "" {
+			fmt.Println("⚠️  Using external collector; local Kubiks UI will not display remote spans unless the data is also ingested locally.")
+		}
+	}
+
+	// Warn if endpoint likely missing OTLP HTTP path
+	if !strings.Contains(resolvedEndpoint, "/v1/") {
+		fmt.Println("⚠️  The OTEL endpoint may be missing the OTLP HTTP path. Example: http://host:4318/v1/traces")
+	}
 
 	cmd, err := e.createCommand()
 	if err != nil {
@@ -153,12 +170,13 @@ func (e *NextJSExecutor) createCommand() (*exec.Cmd, error) {
 	// Get current environment
 	env := os.Environ()
 
-	collectorPort := "7432"
-	collectorURL := fmt.Sprintf("http://localhost:%s/v1/traces", collectorPort)
+	// Resolve exporter configuration (from .env files) and set env vars
+	endpoint, protocol := e.resolveExporterConfig()
 
 	// Set OpenTelemetry environment variables
-	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+collectorURL)
-	env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL=http/json")
+	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+endpoint)
+	env = append(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="+endpoint)
+	env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL="+protocol)
 
 	cmd.Env = env
 
@@ -223,4 +241,74 @@ func (e *NextJSExecutor) getServiceNameFromPackageJSON() string {
 
 	fmt.Printf("📦 Using service name from package.json: %s\n", pkg.Name)
 	return pkg.Name
+}
+
+// resolveExporterConfig returns the OTLP exporter endpoint and protocol.
+// Precedence (first match wins): .env.local, then .env. Fallbacks to local collector.
+func (e *NextJSExecutor) resolveExporterConfig() (string, string) {
+	defaultEndpoint := "http://localhost:7432/v1/traces"
+	defaultProtocol := "http/json"
+
+	vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+
+	endpoint := vals["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
+	if endpoint == "" {
+		endpoint = vals["OTEL_EXPORTER_OTLP_ENDPOINT"]
+	}
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+
+	protocol := vals["OTEL_EXPORTER_OTLP_PROTOCOL"]
+	if protocol == "" {
+		protocol = defaultProtocol
+	}
+
+	return endpoint, protocol
+}
+
+// loadDotEnvFiles parses simple KEY=VALUE lines from the provided files in order.
+// Earlier files take precedence (do not get overridden by later files).
+func (e *NextJSExecutor) loadDotEnvFiles(files []string) map[string]string {
+	values := make(map[string]string)
+
+	setIfEmpty := func(k, v string) {
+		if k == "" || v == "" {
+			return
+		}
+		if _, exists := values[k]; !exists {
+			values[k] = v
+		}
+	}
+
+	for _, name := range files {
+		data, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if strings.HasPrefix(line, "export ") {
+				line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+			}
+			idx := strings.Index(line, "=")
+			if idx <= 0 {
+				continue
+			}
+			k := strings.TrimSpace(line[:idx])
+			v := strings.TrimSpace(line[idx+1:])
+			if len(v) >= 2 {
+				if (strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"")) || (strings.HasPrefix(v, "'") && strings.HasSuffix(v, "'")) {
+					v = v[1 : len(v)-1]
+				}
+			}
+			setIfEmpty(k, v)
+		}
+	}
+
+	return values
 }

--- a/internal/executor/nextjs.go
+++ b/internal/executor/nextjs.go
@@ -2,8 +2,10 @@ package executor
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -39,13 +41,26 @@ func (e *NextJSExecutor) RunDirect() error {
 	fmt.Println("🚀 Starting Next.js development server with OpenTelemetry environment configuration...")
 	fmt.Printf("🏷️  Service name: %s\n", serviceName)
 
-	// Resolve exporter endpoint and protocol from project .env files
-	resolvedEndpoint, resolvedProtocol := e.resolveExporterConfig()
-	fmt.Printf("🔗 OTEL Endpoint: %s\n", resolvedEndpoint)
+	// Resolve base, traces endpoint and protocol from project .env files
+	resolvedBase, resolvedTraces, resolvedProtocol := e.resolveExporterConfig()
+	fmt.Printf("🔗 Local OTEL Endpoint: http://localhost:7432/v1/traces\n")
 	fmt.Printf("📡 OTEL Protocol: %s\n", resolvedProtocol)
+	if resolvedTraces != "" && !strings.Contains(resolvedTraces, ":7432/") {
+		fmt.Printf("🔁 Remote mirror target: %s\n", resolvedTraces)
+	}
+
+	// Resolve logs forwarding configuration
+	logsCfg := e.resolveLogsForwardingConfig(resolvedBase, resolvedTraces)
+	if logsCfg.endpoint != "" {
+		fmt.Printf("📝 OTEL Logs Endpoint: %s\n", logsCfg.endpoint)
+		if logsCfg.protocol != "http/json" {
+			fmt.Println("⚠️  Logs forwarding only supports http/json. Skipping remote logs forwarding.")
+			logsCfg.enabled = false
+		}
+	}
 
 	// Warn if using an external collector (non-localhost)
-	if u, err := url.Parse(resolvedEndpoint); err == nil {
+	if u, err := url.Parse(resolvedTraces); err == nil {
 		host := u.Hostname()
 		if host != "localhost" && host != "127.0.0.1" && host != "" {
 			fmt.Println("⚠️  Using external collector; local Kubiks UI will not display remote spans unless the data is also ingested locally.")
@@ -53,7 +68,7 @@ func (e *NextJSExecutor) RunDirect() error {
 	}
 
 	// Warn if endpoint likely missing OTLP HTTP path
-	if !strings.Contains(resolvedEndpoint, "/v1/") {
+	if !strings.Contains(resolvedTraces, "/v1/") {
 		fmt.Println("⚠️  The OTEL endpoint may be missing the OTLP HTTP path. Example: http://host:4318/v1/traces")
 	}
 
@@ -112,6 +127,11 @@ func (e *NextJSExecutor) RunDirect() error {
 	}()
 
 	// Start goroutines to read and persist stdout/stderr lines
+	var forwardChan chan map[string]interface{}
+	if logsCfg.enabled {
+		forwardChan = make(chan map[string]interface{}, 200)
+		go e.startLogsForwarder(forwardChan, logsCfg)
+	}
 	writeRawLog := func(line, stream string) {
 		// Mirror to console first
 		if stream == "STDERR" {
@@ -135,6 +155,15 @@ func (e *NextJSExecutor) RunDirect() error {
 		}
 		// Store with unknown trace ID; service name will be extracted from resourceAttributes
 		_, _ = db.InsertLog("unknown", string(bytes))
+
+		// Forward to remote OTLP logs endpoint if enabled
+		if logsCfg.enabled {
+			select {
+			case forwardChan <- logRecord:
+			default:
+				// drop if buffer full
+			}
+		}
 	}
 
 	go func() {
@@ -171,12 +200,22 @@ func (e *NextJSExecutor) createCommand() (*exec.Cmd, error) {
 	env := os.Environ()
 
 	// Resolve exporter configuration (from .env files) and set env vars
-	endpoint, protocol := e.resolveExporterConfig()
+	base, tracesEndpoint, protocol := e.resolveExporterConfig()
 
 	// Set OpenTelemetry environment variables
-	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+endpoint)
-	env = append(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="+endpoint)
+	env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+base)
+	// Always send traces to local collector to ensure local DB path is permanent
+	env = append(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:7432/v1/traces")
 	env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL="+protocol)
+
+	// If logs endpoint configured, set it for the child process as well
+	logsCfg := e.resolveLogsForwardingConfig(base, tracesEndpoint)
+	if logsCfg.endpoint != "" {
+		env = append(env, "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="+logsCfg.endpoint)
+		if logsCfg.headers != "" {
+			env = append(env, "OTEL_EXPORTER_OTLP_HEADERS="+logsCfg.headers)
+		}
+	}
 
 	// Ensure service name is set for traces if not provided by the user
 	// Prefer existing OS env or .env values; otherwise use package.json name
@@ -209,6 +248,24 @@ func (e *NextJSExecutor) createCommand() (*exec.Cmd, error) {
 		if _, exists := vals["VERCEL_OTEL_SERVICE_NAME"]; !exists {
 			serviceName := e.getServiceNameFromPackageJSON()
 			env = append(env, "VERCEL_OTEL_SERVICE_NAME="+serviceName)
+		}
+	}
+
+	// Optional: force single-line JSON console output via preload when enabled
+	{
+		vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+		flag := strings.ToLower(strings.TrimSpace(vals["KUBIKS_LOGS_SINGLE_LINE_JSON"]))
+		if flag == "1" || flag == "true" || flag == "yes" || flag == "on" {
+			serviceName := e.getServiceNameFromPackageJSON()
+			if preloadPath, err := e.createConsoleJSONPreload(serviceName); err == nil && preloadPath != "" {
+				// Merge with existing NODE_OPTIONS
+				existing := os.Getenv("NODE_OPTIONS")
+				newVal := strings.TrimSpace(strings.Join([]string{existing, "--require", preloadPath}, " "))
+				if existing == "" {
+					newVal = strings.Join([]string{"--require", preloadPath}, " ")
+				}
+				env = append(env, "NODE_OPTIONS="+newVal)
+			}
 		}
 	}
 
@@ -279,26 +336,33 @@ func (e *NextJSExecutor) getServiceNameFromPackageJSON() string {
 
 // resolveExporterConfig returns the OTLP exporter endpoint and protocol.
 // Precedence (first match wins): .env.local, then .env. Fallbacks to local collector.
-func (e *NextJSExecutor) resolveExporterConfig() (string, string) {
-	defaultEndpoint := "http://localhost:7432/v1/traces"
+func (e *NextJSExecutor) resolveExporterConfig() (string, string, string) {
+	defaultBase := "http://localhost:7432"
 	defaultProtocol := "http/json"
 
 	vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
 
-	endpoint := vals["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
-	if endpoint == "" {
-		endpoint = vals["OTEL_EXPORTER_OTLP_ENDPOINT"]
-	}
-	if endpoint == "" {
-		endpoint = defaultEndpoint
+	// Base endpoint
+	base := vals["OTEL_EXPORTER_OTLP_ENDPOINT"]
+	if base == "" {
+		base = defaultBase
 	}
 
+	// Traces endpoint (override or derived from base)
+	traces := vals["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
+	if traces == "" {
+		traces = normalizeOTLPEndpoint(base, "traces")
+	} else {
+		traces = normalizeOTLPEndpoint(traces, "traces")
+	}
+
+	// Protocol
 	protocol := vals["OTEL_EXPORTER_OTLP_PROTOCOL"]
 	if protocol == "" {
 		protocol = defaultProtocol
 	}
 
-	return endpoint, protocol
+	return base, traces, protocol
 }
 
 // loadDotEnvFiles parses simple KEY=VALUE lines from the provided files in order.
@@ -345,4 +409,284 @@ func (e *NextJSExecutor) loadDotEnvFiles(files []string) map[string]string {
 	}
 
 	return values
+}
+
+// logsForwardingConfig holds settings for forwarding console logs to an OTLP logs endpoint
+type logsForwardingConfig struct {
+	enabled  bool
+	endpoint string
+	headers  string
+	protocol string
+}
+
+// resolveLogsForwardingConfig determines if logs forwarding is enabled and returns config.
+// Rules:
+//   - If OTEL_EXPORTER_OTLP_LOGS_ENDPOINT provided in .env, use it
+//   - Else, if the traces endpoint is local kubiks, disable forwarding by default
+//   - Else, if the traces endpoint is remote and uses http/json, reuse it for logs
+//   - Headers may be set via OTEL_EXPORTER_OTLP_HEADERS
+func (e *NextJSExecutor) resolveLogsForwardingConfig(baseEndpoint string, tracesEndpoint string) logsForwardingConfig {
+	vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+	cfg := logsForwardingConfig{
+		enabled:  false,
+		endpoint: "",
+		headers:  vals["OTEL_EXPORTER_OTLP_HEADERS"],
+		protocol: vals["OTEL_EXPORTER_OTLP_PROTOCOL"],
+	}
+
+	// Highest priority: explicit logs endpoint
+	if v := vals["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]; v != "" {
+		cfg.endpoint = normalizeOTLPEndpoint(v, "logs")
+		cfg.enabled = true
+		if cfg.protocol == "" {
+			cfg.protocol = "http/json"
+		}
+		return cfg
+	}
+
+	// If traces endpoint points to local kubiks, do not forward by default
+	if strings.Contains(tracesEndpoint, ":7432/") || strings.Contains(tracesEndpoint, "localhost:7432/") {
+		return cfg
+	}
+
+	// Otherwise, reuse traces endpoint for logs if protocol is http/json
+	if cfg.protocol == "" {
+		cfg.protocol = "http/json"
+	}
+	if cfg.protocol == "http/json" {
+		// Traces endpoint may be a base or already normalized; derive logs path accordingly
+		if strings.Contains(tracesEndpoint, "/v1/traces") {
+			cfg.endpoint = strings.Replace(tracesEndpoint, "/v1/traces", "/v1/logs", 1)
+		} else {
+			cfg.endpoint = normalizeOTLPEndpoint(baseEndpoint, "logs")
+		}
+		cfg.enabled = true
+	}
+	return cfg
+}
+
+// startLogsForwarder reads records and ships them to the OTLP logs endpoint using OTLP HTTP JSON
+func (e *NextJSExecutor) startLogsForwarder(ch <-chan map[string]interface{}, cfg logsForwardingConfig) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	batch := make([]map[string]interface{}, 0, 50)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		payload := buildOTLPLogsJSONPayload(batch)
+		body, _ := json.Marshal(payload)
+		req, err := http.NewRequest("POST", cfg.endpoint, bytes.NewReader(body))
+		if err == nil {
+			req.Header.Set("Content-Type", "application/json")
+			if cfg.headers != "" {
+				// headers like "k1=v1,k2=v2"
+				for _, kv := range strings.Split(cfg.headers, ",") {
+					kv = strings.TrimSpace(kv)
+					if kv == "" {
+						continue
+					}
+					parts := strings.SplitN(kv, "=", 2)
+					if len(parts) == 2 {
+						req.Header.Set(parts[0], parts[1])
+					}
+				}
+			}
+			_, _ = client.Do(req)
+		}
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case rec, ok := <-ch:
+			if !ok {
+				flush()
+				return
+			}
+			batch = append(batch, rec)
+			if len(batch) >= 50 {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+// buildOTLPLogsJSONPayload wraps flat log records into minimal OTLP HTTP JSON structure
+func buildOTLPLogsJSONPayload(recs []map[string]interface{}) map[string]interface{} {
+	// Convert map -> KeyValue[] per OTLP
+	buildKeyValue := func(m map[string]interface{}) []map[string]interface{} {
+		kv := make([]map[string]interface{}, 0, len(m))
+		for k, v := range m {
+			kv = append(kv, map[string]interface{}{"key": k, "value": anyValue(v)})
+		}
+		return kv
+	}
+
+	// Lift resourceAttributes to resource.attributes once per batch
+	var resourceAttrs []map[string]interface{}
+	if len(recs) > 0 {
+		if ra, ok := recs[0]["resourceAttributes"].(map[string]interface{}); ok {
+			resourceAttrs = buildKeyValue(ra)
+		}
+	}
+
+	// Convert each record
+	logRecords := make([]map[string]interface{}, 0, len(recs))
+	for _, r := range recs {
+		var attrs []map[string]interface{}
+		if am, ok := r["attributes"].(map[string]interface{}); ok {
+			attrs = buildKeyValue(am)
+		}
+		var body map[string]interface{}
+		if b, ok := r["body"]; ok {
+			body = anyValue(b)
+		}
+		logRecords = append(logRecords, map[string]interface{}{
+			"timeUnixNano":         r["timeUnixNano"],
+			"observedTimeUnixNano": r["observedTimeUnixNano"],
+			"severityText":         r["severityText"],
+			"severityNumber":       r["severityNumber"],
+			"body":                 body,
+			"attributes":           attrs,
+		})
+	}
+
+	payload := map[string]interface{}{
+		"resourceLogs": []map[string]interface{}{
+			{
+				"resource": map[string]interface{}{
+					"attributes": resourceAttrs,
+				},
+				"scopeLogs": []map[string]interface{}{
+					{
+						"scope":      map[string]interface{}{},
+						"logRecords": logRecords,
+					},
+				},
+			},
+		},
+	}
+	return payload
+}
+
+// anyValue converts a value to OTLP AnyValue JSON
+func anyValue(v interface{}) map[string]interface{} {
+	switch t := v.(type) {
+	case string:
+		return map[string]interface{}{"stringValue": t}
+	case bool:
+		return map[string]interface{}{"boolValue": t}
+	case float64:
+		return map[string]interface{}{"doubleValue": t}
+	case float32:
+		return map[string]interface{}{"doubleValue": float64(t)}
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return map[string]interface{}{"intValue": fmt.Sprintf("%v", v)}
+	case map[string]interface{}:
+		// If already AnyValue-like, pass through
+		if _, ok := t["stringValue"]; ok {
+			return t
+		}
+		if _, ok := t["boolValue"]; ok {
+			return t
+		}
+		if _, ok := t["doubleValue"]; ok {
+			return t
+		}
+		if _, ok := t["intValue"]; ok {
+			return t
+		}
+		if _, ok := t["bytesValue"]; ok {
+			return t
+		}
+		b, _ := json.Marshal(t)
+		return map[string]interface{}{"stringValue": string(b)}
+	default:
+		return map[string]interface{}{"stringValue": fmt.Sprintf("%v", v)}
+	}
+}
+
+// normalizeOTLPEndpoint appends the OTLP HTTP signal path when the endpoint is a base URL
+// signal should be "traces" or "logs"
+func normalizeOTLPEndpoint(raw string, signal string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	path := u.Path
+	if signal != "traces" && signal != "logs" {
+		signal = "traces"
+	}
+	// Already correct
+	if strings.HasSuffix(path, "/v1/"+signal) {
+		return raw
+	}
+	// If base or "/" -> add /v1/<signal>
+	if path == "" || path == "/" {
+		u.Path = "/v1/" + signal
+		return u.String()
+	}
+	// If exactly /v1 or /v1/ -> add <signal>
+	if path == "/v1" || path == "/v1/" {
+		u.Path = "/v1/" + signal
+		return u.String()
+	}
+	// If contains /v1 but not a signal, best-effort append
+	if strings.HasPrefix(path, "/v1/") && !strings.Contains(path, "/v1/traces") && !strings.Contains(path, "/v1/logs") {
+		if strings.HasSuffix(path, "/") {
+			u.Path = path + signal
+		} else {
+			u.Path = path + "/" + signal
+		}
+		return u.String()
+	}
+	return raw
+}
+
+// createConsoleJSONPreload writes a Node preload script that forces console methods to emit single-line JSON
+func (e *NextJSExecutor) createConsoleJSONPreload(serviceName string) (string, error) {
+	cwd, _ := os.Getwd()
+	baseDir := filepath.Join(cwd, ".kubiks")
+	_ = os.MkdirAll(baseDir, 0o755)
+	preloadPath := filepath.Join(baseDir, "console-json-preload.js")
+	content := `;(function(){
+  try {
+    const LEVELS = { log: "INFO", info: "INFO", warn: "WARN", error: "ERROR", debug: "DEBUG" };
+    const original = { log: console.log, info: console.info, warn: console.warn, error: console.error, debug: console.debug };
+    function toStringSafe(v){
+      try {
+        if (typeof v === 'string') return v;
+        return JSON.stringify(v);
+      } catch (_) {
+        try { return String(v); } catch { return '[unprintable]'; }
+      }
+    }
+    function format(level, args){
+      const msg = args.map(toStringSafe).join(' ');
+      const rec = {
+        time: new Date().toISOString(),
+        level,
+        service: ` + "`" + serviceName + "`" + `,
+        message: msg
+      };
+      return JSON.stringify(rec);
+    }
+    for (const name of Object.keys(original)){
+      console[name] = (...args) => {
+        const lvl = LEVELS[name] || name.toUpperCase();
+        original[name](format(lvl, args));
+      };
+    }
+  } catch (e) { /* ignore */ }
+})();
+`
+	if err := os.WriteFile(preloadPath, []byte(content), 0o644); err != nil {
+		return "", err
+	}
+	return preloadPath, nil
 }

--- a/internal/executor/nextjs.go
+++ b/internal/executor/nextjs.go
@@ -178,6 +178,40 @@ func (e *NextJSExecutor) createCommand() (*exec.Cmd, error) {
 	env = append(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="+endpoint)
 	env = append(env, "OTEL_EXPORTER_OTLP_PROTOCOL="+protocol)
 
+	// Ensure service name is set for traces if not provided by the user
+	// Prefer existing OS env or .env values; otherwise use package.json name
+	if _, ok := os.LookupEnv("OTEL_SERVICE_NAME"); !ok {
+		vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+		if _, exists := vals["OTEL_SERVICE_NAME"]; !exists {
+			serviceName := e.getServiceNameFromPackageJSON()
+			env = append(env, "OTEL_SERVICE_NAME="+serviceName)
+		}
+	}
+
+	// Also ensure OTEL_RESOURCE_ATTRIBUTES has service.name, which some SDKs honor
+	{
+		vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+		osVal, hasOS := os.LookupEnv("OTEL_RESOURCE_ATTRIBUTES")
+		dotVal := vals["OTEL_RESOURCE_ATTRIBUTES"]
+		existing := osVal
+		if !hasOS {
+			existing = dotVal
+		}
+		if !strings.Contains(existing, "service.name=") {
+			serviceName := e.getServiceNameFromPackageJSON()
+			env = append(env, "OTEL_RESOURCE_ATTRIBUTES=service.name="+serviceName)
+		}
+	}
+
+	// Best-effort: set Vercel-specific env if absent, to influence @vercel/otel's default name
+	if _, ok := os.LookupEnv("VERCEL_OTEL_SERVICE_NAME"); !ok {
+		vals := e.loadDotEnvFiles([]string{".env.local", ".env"})
+		if _, exists := vals["VERCEL_OTEL_SERVICE_NAME"]; !exists {
+			serviceName := e.getServiceNameFromPackageJSON()
+			env = append(env, "VERCEL_OTEL_SERVICE_NAME="+serviceName)
+		}
+	}
+
 	cmd.Env = env
 
 	// Set working directory to current directory

--- a/internal/executor/nextjs_test.go
+++ b/internal/executor/nextjs_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,4 +256,111 @@ func TestNextJSExecutor_RunDirect_ValidationFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "package.json") {
 		t.Errorf("Expected package.json error, got: %v", err)
 	}
+}
+
+func writeDotEnv(t *testing.T, lines []string) {
+	t.Helper()
+	content := strings.Join(lines, "\n")
+	if err := os.WriteFile(".env", []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+}
+
+func TestResolveExporterConfig_BaseAndTracesDerivation(t *testing.T) {
+	_, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// minimal package.json and node_modules so executor methods can run
+	pkg := map[string]any{"name": "demo", "dependencies": map[string]any{"next": "15.0.0"}}
+	raw, _ := json.Marshal(pkg)
+	_ = os.WriteFile("package.json", raw, 0644)
+	_ = os.MkdirAll("node_modules", 0755)
+
+	// Base only => traces derived to /v1/traces
+	writeDotEnv(t, []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://example:4318",
+	})
+	ex := &NextJSExecutor{}
+	base, traces, protocol := ex.resolveExporterConfig()
+	if base != "http://example:4318" {
+		t.Fatalf("base mismatch: %s", base)
+	}
+	if traces != "http://example:4318/v1/traces" {
+		t.Fatalf("traces derived mismatch: %s", traces)
+	}
+	if protocol == "" {
+		t.Fatalf("protocol should have defaulted")
+	}
+
+	// Override traces
+	writeDotEnv(t, []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://example:4318",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://override:4318",
+	})
+	base, traces, _ = ex.resolveExporterConfig()
+	if traces != "http://override:4318/v1/traces" {
+		t.Fatalf("traces override normalization failed: %s", traces)
+	}
+}
+
+func TestResolveLogsForwardingConfig(t *testing.T) {
+	_, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+	_ = os.WriteFile("package.json", []byte(`{"name":"demo"}`), 0644)
+	_ = os.MkdirAll("node_modules", 0755)
+
+	ex := &NextJSExecutor{}
+
+	// From base with http/json
+	writeDotEnv(t, []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318",
+		"OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+	})
+	cfg := ex.resolveLogsForwardingConfig("http://collector:4318", "http://collector:4318/v1/traces")
+	if !cfg.enabled || cfg.endpoint != "http://collector:4318/v1/logs" {
+		t.Fatalf("logs cfg from base failed: %+v", cfg)
+	}
+
+	// Explicit logs endpoint wins
+	writeDotEnv(t, []string{
+		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://other:4318",
+	})
+	cfg = ex.resolveLogsForwardingConfig("http://collector:4318", "http://collector:4318/v1/traces")
+	if !cfg.enabled || cfg.endpoint != "http://other:4318/v1/logs" {
+		t.Fatalf("explicit logs endpoint not normalized: %+v", cfg)
+	}
+
+	// Local traces should disable by default
+	writeDotEnv(t, []string{})
+	cfg = ex.resolveLogsForwardingConfig("http://collector:4318", "http://localhost:7432/v1/traces")
+	if cfg.enabled {
+		t.Fatalf("logs forwarding should be disabled for local traces endpoint")
+	}
+}
+
+func TestCreateCommand_SetsLocalTracesAndPreload(t *testing.T) {
+	_, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+	_ = os.WriteFile("package.json", []byte(`{"name":"demo"}`), 0644)
+	_ = os.MkdirAll("node_modules", 0755)
+
+	// Enable single-line JSON and remote base
+	writeDotEnv(t, []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318",
+		"KUBIKS_LOGS_SINGLE_LINE_JSON=true",
+	})
+	ex := &NextJSExecutor{}
+	cmd, err := ex.createCommand()
+	if err != nil {
+		t.Fatalf("createCommand error: %v", err)
+	}
+	env := strings.Join(cmd.Env, "\n")
+	if !strings.Contains(env, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:7432/v1/traces") {
+		t.Fatalf("local traces endpoint not set in env")
+	}
+	if !strings.Contains(env, "NODE_OPTIONS=") || !strings.Contains(env, "--require") || !strings.Contains(env, ".kubiks/console-json-preload.js") {
+		t.Fatalf("NODE_OPTIONS preload not set: %s", env)
+	}
+	// Print env for easier debugging when failing
+	_ = fmt.Sprintf("%d", len(env))
 }

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -1,11 +1,16 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/kubiks-inc/kubiks-cli/internal/database"
 	"github.com/kubiks-inc/kubiks-cli/pkg/types"
@@ -15,6 +20,11 @@ import (
 type Server struct {
 	db   *database.DB
 	port string
+	// mirroring config
+	mirrorEnabled    bool
+	mirrorTracesURL  string
+	mirrorLogsURL    string
+	mirrorHeadersRaw string
 }
 
 // NewServer creates a new server instance
@@ -25,10 +35,28 @@ func NewServer(port string) (*Server, error) {
 		return nil, fmt.Errorf("failed to initialize database: %w", err)
 	}
 
-	return &Server{
+	s := &Server{
 		db:   db,
 		port: port,
-	}, nil
+	}
+
+	// Resolve mirroring configuration from .env.local/.env
+	base, tracesURL, logsURL, headers := resolveMirrorConfig()
+	// Enable mirroring if any remote target is non-empty and not pointing to our own OTEL port
+	if tracesURL != "" || logsURL != "" {
+		// avoid self-loop to local server
+		if !isLocalOTELURL(tracesURL, port) || !isLocalOTELURL(logsURL, port) {
+			s.mirrorEnabled = true
+			s.mirrorTracesURL = tracesURL
+			s.mirrorLogsURL = logsURL
+			s.mirrorHeadersRaw = headers
+			if s.mirrorTracesURL != "" || s.mirrorLogsURL != "" {
+				fmt.Printf("🔁 OTLP mirroring enabled to base %s (traces=%s logs=%s)\n", base, s.mirrorTracesURL, s.mirrorLogsURL)
+			}
+		}
+	}
+
+	return s, nil
 }
 
 // GetDB returns the database instance
@@ -91,6 +119,11 @@ func (s *Server) OTELLogsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, `{"partialSuccess":{},"inserted":%d}`, count)
+
+	// Mirror to remote logs endpoint if enabled
+	if s.mirrorEnabled && s.mirrorLogsURL != "" && !isLocalOTELURL(s.mirrorLogsURL, s.port) {
+		go s.forwardOTLPJSON(s.mirrorLogsURL, body, s.mirrorHeadersRaw)
+	}
 }
 
 // OTELMetricsHandler handles OTEL metrics endpoint
@@ -145,6 +178,11 @@ func (s *Server) OTELTracesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, `{"partialSuccess":{},"inserted":%d}`, count)
+
+	// Mirror to remote traces endpoint if enabled
+	if s.mirrorEnabled && s.mirrorTracesURL != "" && !isLocalOTELURL(s.mirrorTracesURL, s.port) {
+		go s.forwardOTLPJSON(s.mirrorTracesURL, body, s.mirrorHeadersRaw)
+	}
 }
 
 // StatsHandler returns database statistics
@@ -163,7 +201,7 @@ func (s *Server) StatsHandler(w http.ResponseWriter, r *http.Request) {
 		"metrics_count": %d,
 		"traces_count": %d,
 		"database_path": "%s"
-	}`, stats["logs_count"], stats["metrics_count"], stats["traces_count"], types.GetDatabasePath())
+		}`, stats["logs_count"], stats["metrics_count"], stats["traces_count"], types.GetDatabasePath())
 }
 
 // CleanHandler deletes all data
@@ -375,4 +413,136 @@ func (s *Server) LogsByTraceHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(results)
+}
+
+// forwardOTLPJSON forwards an OTLP HTTP JSON payload to the given URL with optional headers
+func (s *Server) forwardOTLPJSON(targetURL string, payload []byte, headersRaw string) {
+	if targetURL == "" {
+		return
+	}
+	req, err := http.NewRequest("POST", targetURL, bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// headers string format: key=value,key2=value2
+	for _, kv := range strings.Split(headersRaw, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			req.Header.Set(parts[0], parts[1])
+		}
+	}
+	client := &http.Client{}
+	_, _ = client.Do(req)
+}
+
+// resolveMirrorConfig loads .env files to determine remote OTLP endpoints for mirroring
+// Precedence: .env.local then .env
+func resolveMirrorConfig() (base string, tracesURL string, logsURL string, headers string) {
+	vals := loadDotEnvFiles([]string{".env.local", ".env"})
+	base = vals["OTEL_EXPORTER_OTLP_ENDPOINT"]
+	if base == "" {
+		base = ""
+	}
+	tracesURL = vals["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
+	logsURL = vals["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"]
+	if tracesURL == "" && base != "" {
+		tracesURL = normalizeOTLPEndpoint(base, "traces")
+	}
+	if logsURL == "" && base != "" {
+		logsURL = normalizeOTLPEndpoint(base, "logs")
+	}
+	headers = vals["OTEL_EXPORTER_OTLP_HEADERS"]
+	return
+}
+
+// isLocalOTELURL returns true if the URL points to this server's OTEL port
+func isLocalOTELURL(raw string, otelPort string) bool {
+	if raw == "" {
+		return false
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := u.Host
+	return strings.Contains(host, ":"+otelPort)
+}
+
+// normalizeOTLPEndpoint appends /v1/<signal> when given a base URL
+func normalizeOTLPEndpoint(raw string, signal string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	p := u.Path
+	if strings.HasSuffix(p, "/v1/"+signal) {
+		return raw
+	}
+	if p == "" || p == "/" {
+		u.Path = "/v1/" + signal
+		return u.String()
+	}
+	if p == "/v1" || p == "/v1/" {
+		u.Path = "/v1/" + signal
+		return u.String()
+	}
+	if strings.HasPrefix(p, "/v1/") && !strings.Contains(p, "/v1/traces") && !strings.Contains(p, "/v1/logs") {
+		if strings.HasSuffix(p, "/") {
+			u.Path = p + signal
+		} else {
+			u.Path = p + "/" + signal
+		}
+		return u.String()
+	}
+	return raw
+}
+
+// loadDotEnvFiles is a lightweight parser for KEY=VALUE env files
+func loadDotEnvFiles(files []string) map[string]string {
+	values := make(map[string]string)
+	setIfEmpty := func(k, v string) {
+		if k == "" || v == "" {
+			return
+		}
+		if _, exists := values[k]; !exists {
+			values[k] = v
+		}
+	}
+	for _, name := range files {
+		data, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			if strings.HasPrefix(line, "export ") {
+				line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+			}
+			idx := strings.Index(line, "=")
+			if idx <= 0 {
+				continue
+			}
+			k := strings.TrimSpace(line[:idx])
+			v := strings.TrimSpace(line[idx+1:])
+			if len(v) >= 2 {
+				if (strings.HasPrefix(v, "\"") && strings.HasSuffix(v, "\"")) || (strings.HasPrefix(v, "'")) && strings.HasSuffix(v, "'") {
+					v = v[1 : len(v)-1]
+				}
+			}
+			setIfEmpty(k, v)
+		}
+	}
+	return values
 }

--- a/internal/handlers/server_test.go
+++ b/internal/handlers/server_test.go
@@ -425,6 +425,62 @@ func TestServer_StatsHandler_DatabaseError(t *testing.T) {
 	}
 }
 
+// Mirror helpers
+func TestNormalizeOTLPEndpoint(t *testing.T) {
+	cases := []struct{ in, signal, want string }{
+		{"http://host:4318", "traces", "http://host:4318/v1/traces"},
+		{"http://host:4318/", "logs", "http://host:4318/v1/logs"},
+		{"http://host:4318/v1", "logs", "http://host:4318/v1/logs"},
+		{"http://host:4318/v1/", "traces", "http://host:4318/v1/traces"},
+		{"http://host:4318/v1/custom", "traces", "http://host:4318/v1/custom/traces"},
+	}
+	for _, c := range cases {
+		if got := normalizeOTLPEndpoint(c.in, c.signal); got != c.want {
+			t.Fatalf("normalizeOTLPEndpoint(%s,%s)=%s want %s", c.in, c.signal, got, c.want)
+		}
+	}
+}
+
+func TestIsLocalOTELURL(t *testing.T) {
+	if !isLocalOTELURL("http://localhost:7432/v1/traces", "7432") {
+		t.Fatalf("expected local url to be detected")
+	}
+	if isLocalOTELURL("http://remote:4318/v1/traces", "7432") {
+		t.Fatalf("did not expect remote url to be considered local")
+	}
+}
+
+func TestForwardOTLPJSON(t *testing.T) {
+	// Setup a local HTTP server to validate forwarding
+	received := make(chan *http.Request, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	s := &Server{port: "7432"}
+	payload := []byte(`{"hello":"world"}`)
+	headers := "Authorization=Bearer token-x, X-Test=1"
+	// exercise
+	s.forwardOTLPJSON(ts.URL, payload, headers)
+
+	select {
+	case req := <-received:
+		if ct := req.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("content-type mismatch: %s", ct)
+		}
+		if req.Header.Get("Authorization") != "Bearer token-x" {
+			t.Fatalf("auth header missing")
+		}
+		if req.Header.Get("X-Test") != "1" {
+			t.Fatalf("x-test header missing")
+		}
+	default:
+		t.Fatalf("no request received")
+	}
+}
+
 // badReader simulates an io.Reader that always returns an error
 type badReader struct{}
 

--- a/internal/mcpconfig/manager_test.go
+++ b/internal/mcpconfig/manager_test.go
@@ -3,6 +3,7 @@ package mcpconfig
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -240,5 +241,81 @@ func TestConstants(t *testing.T) {
 
 	if KubiksServerURL != "http://localhost:7433/mcp/sse" {
 		t.Errorf("KubiksServerURL = %v, want 'http://localhost:7433/mcp/sse'", KubiksServerURL)
+	}
+}
+
+// Additional coverage: load/save error and corrupted file paths
+func TestManager_loadConfig_ReadError(t *testing.T) {
+	// Create manager with configPath pointing to a directory (ReadFile will fail)
+	tempDir := t.TempDir()
+	mgr := &Manager{configPath: filepath.Join(tempDir, "mcp.json")}
+	// Create a directory at the file path
+	if err := os.MkdirAll(mgr.configPath, 0755); err != nil {
+		t.Fatalf("failed to create dir at configPath: %v", err)
+	}
+	if _, err := mgr.loadConfig(); err == nil {
+		t.Fatalf("expected read error when configPath is a directory")
+	}
+}
+
+func TestManager_loadConfig_EmptyFile(t *testing.T) {
+	mgr, cleanup := setupTestManager(t)
+	defer cleanup()
+	// ensure dir exists
+	_ = os.MkdirAll(filepath.Dir(mgr.configPath), 0755)
+	// write empty file
+	if err := os.WriteFile(mgr.configPath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write empty file: %v", err)
+	}
+	cfg, err := mgr.loadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg) != 0 {
+		t.Fatalf("expected empty config, got %v", cfg)
+	}
+}
+
+func TestManager_loadConfig_CorruptedJSON_Backup(t *testing.T) {
+	mgr, cleanup := setupTestManager(t)
+	defer cleanup()
+	_ = os.MkdirAll(filepath.Dir(mgr.configPath), 0755)
+	if err := os.WriteFile(mgr.configPath, []byte("{not-json"), 0644); err != nil {
+		t.Fatalf("failed to write corrupted file: %v", err)
+	}
+	cfg, err := mgr.loadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg) != 0 {
+		t.Fatalf("expected empty config on corrupted file, got %v", cfg)
+	}
+	// backup should exist next to configPath with .backup.
+	dir := filepath.Dir(mgr.configPath)
+	entries, _ := os.ReadDir(dir)
+	found := false
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, "mcp.json.backup.") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected backup file to be created for corrupted JSON")
+	}
+}
+
+func TestManager_saveConfig_CreateDirError(t *testing.T) {
+	// Create a file where the directory should be to force MkdirAll error
+	tempDir := t.TempDir()
+	badDir := filepath.Join(tempDir, ".cursor")
+	if err := os.WriteFile(badDir, []byte("block"), 0644); err != nil {
+		t.Fatalf("failed to create blocking file: %v", err)
+	}
+	mgr := &Manager{configPath: filepath.Join(badDir, "mcp.json")}
+	err := mgr.saveConfig(map[string]interface{}{"k": "v"})
+	if err == nil || !strings.Contains(err.Error(), "failed to create config directory") {
+		t.Fatalf("expected create dir error, got %v", err)
 	}
 }

--- a/ui/src/containers/traces/logs-tab.tsx
+++ b/ui/src/containers/traces/logs-tab.tsx
@@ -35,6 +35,47 @@ function bodyToString(body: any): string {
   return String(body);
 }
 
+// Parse body to object, supporting both OTEL AnyValue and plain JSON string bodies
+function parseBodyObject(body: any): any | null {
+  if (!body) return null;
+  // If body is a plain JSON string
+  if (typeof body === 'string') {
+    const s = body.trim();
+    if (s.startsWith('{') || s.startsWith('[')) {
+      try { return JSON.parse(s); } catch { return null; }
+    }
+    return null;
+  }
+  // If body is an OTEL AnyValue object with stringValue
+  if (typeof body === 'object') {
+    const v = (body as any).stringValue ?? (body as any).intValue ?? (body as any).doubleValue ?? (body as any).boolValue ?? (body as any).bytesValue ?? body;
+    if (typeof v === 'string') {
+      const s = v.trim();
+      if (s.startsWith('{') || s.startsWith('[')) {
+        try { return JSON.parse(s); } catch { return null; }
+      }
+    }
+  }
+  return null;
+}
+
+function deriveSeverity(log: LogRecord): string {
+  // Priority: attributes.log.level -> parsed body.level/severity -> severityText
+  const attrs = log.attributes || {};
+  const fromAttrs = (attrs['log.level'] || attrs['level']) as string | undefined;
+  if (fromAttrs) return String(fromAttrs).toUpperCase();
+  const parsed = parseBodyObject(log.body);
+  const fromBody = (parsed?.level || parsed?.severity) as string | undefined;
+  if (fromBody) return String(fromBody).toUpperCase();
+  return String(log.severityText || '').toUpperCase();
+}
+
+function extractMessage(log: LogRecord): string {
+  const parsed = parseBodyObject(log.body);
+  if (parsed && typeof parsed.message === 'string') return parsed.message;
+  return bodyToString(log.body);
+}
+
 export function LogsTable() {
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const { data, error, isLoading } = useSWR<LogRecord[]>(
@@ -85,7 +126,8 @@ export function LogsTable() {
             </TableHeader>
             <TableBody>
               {logs.map((log, idx) => {
-                const fullMessage = bodyToString(log.body);
+                const severity = deriveSeverity(log);
+                const fullMessage = extractMessage(log);
                 const isExpanded = expanded.has(idx);
                 return (
                   <Fragment key={idx}>
@@ -95,7 +137,7 @@ export function LogsTable() {
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center gap-2">
-                          <span className={`text-xs px-2 py-1 rounded font-mono ${severityClasses(log.severityText)}`}>{String(log.severityText ?? '')}</span>
+                          <span className={`text-xs px-2 py-1 rounded font-mono ${severityClasses(severity)}`}>{severity}</span>
                         </div>
                       </TableCell>
                       <TableCell>


### PR DESCRIPTION
- Optional remote exporter mirroring - but always send traces to local collector (http://localhost:7432/v1/traces)

- Normalize OTLP endpoints from base; allow per‑signal overrides; support headers/protocol

- Forward console logs as OTLP HTTP/JSON (spec‑compliant: resource.attributes, KeyValue attributes, AnyValue body). Optional single‑line JSON console: KUBIKS_LOGS_SINGLE_LINE_JSON=true

- Web UI derives log level from attributes.log.level/level or JSON body (fallback: severityText) to support structured logging option

README updated, tests written